### PR TITLE
Make taxonomies available to Sections

### DIFF
--- a/components/content/src/library.rs
+++ b/components/content/src/library.rs
@@ -365,7 +365,7 @@ impl Library {
             Self::add_translation(&mut self.translations, config, &page.file.canonical, &path);
 
             let mut parent_section_path = page.file.parent.join(&parent_filename);
-            sections_taxa.insert(parent_section_path.clone(), empty_tax.clone());
+            sections_taxa.entry(parent_section_path.clone()).or_insert(empty_tax.clone());
             while let Some(parent_section) = self.sections.get_mut(&parent_section_path) {
                 let is_transparent = parent_section.meta.transparent;
                 parent_section.pages.push(path.clone());

--- a/components/content/src/library.rs
+++ b/components/content/src/library.rs
@@ -406,9 +406,22 @@ impl Library {
             }
         }
 
-        dbg!(sections_taxa);
-        // TODO: Convert base_taxa to Taxonomy and propagate taxonomies to parent sections here
+        dbg!(&sections_taxa);
 
+        // TODO: Just build from self.taxonomies_def here? Filter on sections in file paths? e.g. filter prefix
+        dbg!(&self.taxonomies_def);
+
+        for (section, taxo_data) in sections_taxa {
+            // Convert base_taxa to Taxonomy and add to this Section
+            let taxonomies = self.find_taxonomies_with_def(config, &taxo_data);
+            dbg!(&taxonomies);
+            if let Some(v) = self.sections.get_mut(&section) {
+                v.taxonomies = taxonomies;
+            }
+
+            // TODO: Also merge into parent sections
+        }
+        dbg!(&self.sections);
         // And once we have all the pages assigned to their section, we sort them
         self.sort_section_pages();
     }

--- a/components/content/src/library.rs
+++ b/components/content/src/library.rs
@@ -44,6 +44,8 @@ impl Library {
 
         for (lang, options) in &config.languages {
             let mut taxas = AHashMap::new();
+
+            // For each lang, for each taxonomy in that lang generate an empty HashMap to hold its term -> paths
             for tax_def in &options.taxonomies {
                 taxas.insert(tax_def.slug.clone(), AHashMap::new());
                 lib.taxo_name_to_slug.insert(tax_def.name.clone(), tax_def.slug.clone());
@@ -51,6 +53,22 @@ impl Library {
             lib.taxonomies_def.insert(lang.to_string(), taxas);
         }
         lib
+    }
+
+    fn generate_empty_tax_def(
+        config: &Config,
+    ) -> AHashMap<String, AHashMap<String, AHashMap<String, Vec<PathBuf>>>> {
+        let mut taxonomies_def = AHashMap::new();
+        for (lang, options) in &config.languages {
+            let mut taxas = AHashMap::new();
+
+            // For each lang, for each taxonomy in that lang generate an empty HashMap to hold its term -> paths
+            for tax_def in &options.taxonomies {
+                taxas.insert(tax_def.slug.clone(), AHashMap::new());
+            }
+            taxonomies_def.insert(lang.to_string(), taxas);
+        }
+        taxonomies_def
     }
 
     fn insert_reverse_aliases(&mut self, file_path: &Path, entries: Vec<String>) {
@@ -97,6 +115,7 @@ impl Library {
                     .get_mut(&self.taxo_name_to_slug[taxa_name])
                     .expect("taxa not found");
 
+                // Global taxonomy insertion happens here
                 if !taxa_def.contains_key(term) {
                     taxa_def.insert(term.to_string(), Vec::new());
                 }
@@ -105,6 +124,33 @@ impl Library {
         }
 
         self.pages.insert(file_path, page);
+    }
+
+    /// Given a page and a mutable reference to AHashMap<lang, AHashMap<taxonomy_slug, AHashMap<taxonomy_term, page_path>>>
+    /// Inserts the taxonomy terms from the page
+    pub fn insert_taxa_page(
+        taxo_name_to_slug: &AHashMap<String, String>,
+        page: &Page,
+        taxonomies_def: &mut AHashMap<String, AHashMap<String, AHashMap<String, Vec<PathBuf>>>>,
+    ) {
+        // TODO: Limit to section.lang passed as argument?
+        for (taxa_name, terms) in &page.meta.taxonomies {
+            for term in terms {
+                // Safe unwraps as we create all lang/taxa and we validated that they are correct
+                // before getting there
+                let taxa_def = taxonomies_def
+                    .get_mut(&page.lang)
+                    .expect("lang not found")
+                    .get_mut(&taxo_name_to_slug[taxa_name])
+                    .expect("taxa not found");
+
+                // Global taxonomy insertion happens here
+                if !taxa_def.contains_key(term) {
+                    taxa_def.insert(term.to_string(), Vec::new());
+                }
+                taxa_def.get_mut(term).unwrap().push(page.file.path.clone());
+            }
+        }
     }
 
     pub fn insert_section(&mut self, section: Section) {
@@ -146,9 +192,19 @@ impl Library {
 
     /// This is called _before_ rendering the markdown the pages/sections
     pub fn find_taxonomies(&self, config: &Config) -> Vec<Taxonomy> {
+        self.find_taxonomies_with_def(config, &self.taxonomies_def)
+    }
+
+    /// self.pages maps page PathBuf file path to Page struct
+    pub fn find_taxonomies_with_def(
+        &self,
+        config: &Config,
+        taxonomies_def: &AHashMap<String, AHashMap<String, AHashMap<String, Vec<PathBuf>>>>,
+    ) -> Vec<Taxonomy> {
         let mut taxonomies = Vec::new();
 
-        for (lang, taxonomies_data) in &self.taxonomies_def {
+        // taxonomies_def has been filled during page insertion - insert_page(), called by add_page()
+        for (lang, taxonomies_data) in taxonomies_def {
             for (taxa_slug, terms_pages) in taxonomies_data {
                 let taxo_config = &config.languages[lang]
                     .taxonomies
@@ -208,20 +264,25 @@ impl Library {
         }
     }
 
+    pub fn add_translation(
+        translations: &mut AHashMap<PathBuf, AHashSet<PathBuf>>,
+        config: &Config,
+        entry: &Path,
+        path: &Path,
+    ) {
+        if config.is_multilingual() {
+            translations
+                .entry(entry.to_path_buf())
+                .and_modify(|trans| {
+                    trans.insert(path.to_path_buf());
+                })
+                .or_insert(set! {path.to_path_buf()});
+        }
+    }
+
     /// Find out the direct subsections of each subsection if there are some
     /// as well as the pages for each section
     pub fn populate_sections(&mut self, config: &Config, content_path: &Path) {
-        let mut add_translation = |entry: &Path, path: &Path| {
-            if config.is_multilingual() {
-                self.translations
-                    .entry(entry.to_path_buf())
-                    .and_modify(|trans| {
-                        trans.insert(path.to_path_buf());
-                    })
-                    .or_insert(set! {path.to_path_buf()});
-            }
-        };
-
         let mut ancestors = AHashMap::new();
         let mut subsections = AHashMap::new();
         let mut sections_weight = AHashMap::new();
@@ -238,7 +299,7 @@ impl Library {
                     .push(section.file.path.clone());
             }
 
-            add_translation(&section.file.canonical, path);
+            Self::add_translation(&mut self.translations, config, &section.file.canonical, &path);
 
             // Root sections have no ancestors
             if section.is_index() {
@@ -291,15 +352,31 @@ impl Library {
             }
         }
 
+        // PathBuf ? > Lang > Taxonomy Name > Taxonomy Term > Page paths
+        let mut sections_taxa: AHashMap<
+            PathBuf,
+            AHashMap<String, AHashMap<String, AHashMap<String, Vec<PathBuf>>>>,
+        > = AHashMap::new();
+        let empty_tax = Self::generate_empty_tax_def(&config);
+
         // Then once we took care of the sections, we find the pages of each section
         for (path, page) in self.pages.iter_mut() {
             let parent_filename = &index_filename_by_lang[&page.lang];
-            add_translation(&page.file.canonical, path);
-            let mut parent_section_path = page.file.parent.join(&parent_filename);
+            Self::add_translation(&mut self.translations, config, &page.file.canonical, &path);
 
+            let mut parent_section_path = page.file.parent.join(&parent_filename);
+            sections_taxa.insert(parent_section_path.clone(), empty_tax.clone());
             while let Some(parent_section) = self.sections.get_mut(&parent_section_path) {
                 let is_transparent = parent_section.meta.transparent;
                 parent_section.pages.push(path.clone());
+                // TODO: Read and push taxonomies here?
+                // First push to immediate section (i.e. page parent), then bubble up to ancestors - merging taxonomies
+
+                let base_taxa = sections_taxa
+                    .get_mut(&parent_section_path)
+                    .expect("missing parent section path");
+                Self::insert_taxa_page(&self.taxo_name_to_slug, page, base_taxa);
+
                 page.ancestors = ancestors.get(&parent_section_path).cloned().unwrap_or_default();
                 // Don't forget to push the actual parent
                 page.ancestors.push(parent_section.file.relative.clone());
@@ -328,6 +405,9 @@ impl Library {
                 }
             }
         }
+
+        dbg!(sections_taxa);
+        // TODO: Convert base_taxa to Taxonomy and propagate taxonomies to parent sections here
 
         // And once we have all the pages assigned to their section, we sort them
         self.sort_section_pages();

--- a/components/content/src/section.rs
+++ b/components/content/src/section.rs
@@ -15,6 +15,7 @@ use crate::front_matter::{split_section_content, SectionFrontMatter};
 use crate::library::Library;
 use crate::ser::{SectionSerMode, SerializingSection};
 use crate::utils::{find_related_assets, get_reading_analytics, has_anchor};
+use crate::Taxonomy;
 
 // Default is used to create a default index section if there is no _index.md in the root content directory
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -61,6 +62,8 @@ pub struct Section {
     pub internal_links: Vec<(String, Option<String>)>,
     /// The list of all links to external webpages. They can be validated by the `link_checker`.
     pub external_links: Vec<String>,
+    /// Taxonomies specific to the section (i.e. all pages in this section and sub-sections)
+    pub taxonomies: Vec<Taxonomy>,
 }
 
 impl Section {

--- a/components/content/src/ser.rs
+++ b/components/content/src/ser.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use serde::Serialize;
 
 use crate::library::Library;
+use crate::taxonomies::SerializedTaxonomy;
 use crate::{Page, Section};
 use libs::tera::{Map, Value};
 use utils::table_of_contents::Heading;
@@ -155,6 +156,7 @@ pub struct SerializingSection<'a> {
     subsections: Vec<&'a str>,
     translations: Vec<TranslatedContent<'a>>,
     backlinks: Vec<BackLink<'a>>,
+    taxonomies: Vec<SerializedTaxonomy<'a>>,
 }
 
 #[derive(Debug)]
@@ -174,10 +176,17 @@ impl<'a> SerializingSection<'a> {
         let mut subsections = Vec::with_capacity(section.subsections.len());
         let mut translations = Vec::new();
         let mut backlinks = Vec::new();
+        let mut taxonomies = Vec::new();
 
         match mode {
             SectionSerMode::ForMarkdown => {}
             SectionSerMode::MetadataOnly(lib) | SectionSerMode::Full(lib) => {
+                taxonomies = section
+                    .taxonomies
+                    .iter()
+                    .map(|t| SerializedTaxonomy::from_taxonomy(t, lib))
+                    .collect();
+
                 translations = lib.find_translations(&section.file.canonical);
                 subsections = section
                     .subsections
@@ -216,6 +225,7 @@ impl<'a> SerializingSection<'a> {
             subsections,
             translations,
             backlinks,
+            taxonomies,
         }
     }
 }


### PR DESCRIPTION
First step to make section-specific taxonomies renderable on Section pages

Taxonomies are built from each page in a leaf section, and then will be merged upwards to parent sections.

Leaf section taxonomy now partially works:

```
[components/content/src/library.rs:409] sections_taxa = {
    "/home/archie/octozola/content/blog/_index.md": {
        "en": {
            "categories": {
                "Rust": [
                    "/home/archie/octozola/content/blog/2020-08-29-rust-ses.md",
                ],
            },
        },
    },
}
```

TODO: Check for multiple files, Convert these to `Taxonomy` structs, then propagate to ancestor sections
